### PR TITLE
remove 3.6, add 3.9 from github action

### DIFF
--- a/.github/workflows/tiptapy.yml
+++ b/.github/workflows/tiptapy.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7]
+        python-version: [ 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Python 3.6 will be soon EOL